### PR TITLE
#7: Extend messagesToJson to support reporting well known fields, suc…

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,10 @@
  * @property {string} source
  * @property {boolean} fatal
  * @property {string} stack
+ * @property {string} actual
+ * @property {string|Array<string>} expected
+ * @property {string} url
+ * @property {string} note
  *
  * @typedef _JsonFile
  * @property {string} path
@@ -96,7 +100,11 @@ function messagesToJson(messages, options) {
         ruleId: message.ruleId || null,
         source: message.source || null,
         fatal: message.fatal,
-        stack: message.stack || null
+        stack: message.stack || null,
+        actual: message.actual || null,
+        expected: message.expected || null,
+        url: message.url || null,
+        note: message.note || null
       })
     }
   }

--- a/readme.md
+++ b/readme.md
@@ -72,7 +72,7 @@ console.log(reporterJson([one, two]))
 Yields:
 
 ```json
-[{"path":"test/fixture/1.js","cwd":"/Users/tilde/projects/oss/vfile-reporter-json","history":["test/fixture/1.js"],"messages":[{"reason":"Warning!","line":2,"column":4,"position":{"start":{"line":2,"column":4},"end":{"line":null,"column":null}},"ruleId":null,"source":null,"fatal":false,"stack":null}]},{"path":"test/fixture/2.js","cwd":"/Users/tilde/projects/oss/vfile-reporter-json","history":["test/fixture/2.js"],"messages":[]}]
+[{"path":"test/fixture/1.js","cwd":"/Users/tilde/projects/oss/vfile-reporter-json","history":["test/fixture/1.js"],"messages":[{"reason":"Warning!","line":2,"column":4,"position":{"start":{"line":2,"column":4},"end":{"line":null,"column":null}},"ruleId":null,"source":null,"fatal":false,"stack":null,"actual":null,"expected":null,"url":null,"note":null}]},{"path":"test/fixture/2.js","cwd":"/Users/tilde/projects/oss/vfile-reporter-json","history":["test/fixture/2.js"],"messages":[]}]
 ```
 
 ## API

--- a/test.js
+++ b/test.js
@@ -117,7 +117,11 @@ test('reporterJson(vfiles)', function (t) {
             ruleId: null,
             source: null,
             fatal: false,
-            stack: null
+            stack: null,
+            actual: null,
+            expected: null,
+            url: null,
+            note: null
           }
         ]
       }
@@ -156,7 +160,11 @@ test('reporterJson(vfiles)', function (t) {
             ruleId: null,
             source: null,
             fatal: true,
-            stack: null
+            stack: null,
+            actual: null,
+            expected: null,
+            url: null,
+            note: null
           }
         ]
       }
@@ -183,7 +191,11 @@ test('reporterJson(vfiles)', function (t) {
             ruleId: null,
             source: null,
             fatal: true,
-            stack: null
+            stack: null,
+            actual: null,
+            expected: null,
+            url: null,
+            note: null
           }
         ]
       }
@@ -216,7 +228,11 @@ test('reporterJson(vfiles)', function (t) {
             ruleId: null,
             source: null,
             fatal: true,
-            stack: null
+            stack: null,
+            actual: null,
+            expected: null,
+            url: null,
+            note: null
           }
         ]
       }
@@ -246,7 +262,11 @@ test('reporterJson(vfiles)', function (t) {
             ruleId: null,
             source: null,
             fatal: false,
-            stack: null
+            stack: null,
+            actual: null,
+            expected: null,
+            url: null,
+            note: null
           }
         ]
       }
@@ -295,7 +315,11 @@ test('reporterJson(vfiles)', function (t) {
             ruleId: null,
             source: null,
             fatal: false,
-            stack: null
+            stack: null,
+            actual: null,
+            expected: null,
+            url: null,
+            note: null
           }
         ]
       }
@@ -327,7 +351,11 @@ test('reporterJson(vfiles)', function (t) {
             ruleId: null,
             source: null,
             fatal: true,
-            stack: null
+            stack: null,
+            actual: null,
+            expected: null,
+            url: null,
+            note: null
           }
         ]
       }


### PR DESCRIPTION
…h as actual, expected, url and note; Update tests to reflect extra fields

<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/vfile/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/vfile/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/vfile/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Avfile&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Implement #7 

* Extended `messagesToJson` to support reporting well known fields, such as actual, expected, url and note
* Updated tests to reflect extra fields
* Updated documentation to include new fields

<!--do not edit: pr-->
